### PR TITLE
I fixed the status of events in admin page.

### DIFF
--- a/app/Http/Controllers/Admin/EventsController.php
+++ b/app/Http/Controllers/Admin/EventsController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Event;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Carbon;
 
 class EventsController extends Controller
 {
@@ -22,7 +23,11 @@ class EventsController extends Controller
     public function show()
     {
         $all_events = Event::oldest()->paginate(10);
-        return view('admin.events.index')->with('all_events',$all_events);
+        $today = Carbon::today();
+        
+        return view('admin.events.index')
+            ->with('all_events',$all_events)
+            ->with('today',$today);
     }
 
     public function create()

--- a/resources/views/admin/events/index.blade.php
+++ b/resources/views/admin/events/index.blade.php
@@ -19,7 +19,7 @@
                 <ul>
                     <li>
                         <i class="fs-4 pt-2 fa-solid fa-circle text-secondary icon-status"></i>
-                        <span class="fs-4">available</span>
+                        <span class="fs-4">done</span>
                     </li>
                     <li>
                         <i class="fs-4 pt-2 fa-solid fa-circle text-danger icon-status"></i>
@@ -27,7 +27,7 @@
                     </li>
                     <li>
                         <i class="fs-4 pt-2 fa-solid fa-circle text-success icon-status"></i>
-                        <span class="fs-4 pe-3">done</span>
+                        <span class="fs-4 pe-3">available</span>
                     </li>
                 </ul>
             </div>
@@ -59,7 +59,15 @@
                             <td>{{ $event->location }}</td>
                             <td>{{ $event->created_at }}</td>
                             <td>{{ $event->updated_at }}</td>
-                            <td><i class="fa-solid fa-circle text-success"></i></td>
+                            <td>
+                                @if ($event->date < $today)
+                                    <i class="fa-solid fa-circle text-secondary"></i>
+                                @elseif ($event->joinEvents->count() >= 10)
+                                    <i class="fa-solid fa-circle text-danger"></i>
+                                @else
+                                    <i class="fa-solid fa-circle text-success"></i>
+                                @endif
+                            </td>
                             <td>
                                 <div class="dropdown">
                                     <button class="btn" data-bs-toggle="dropdown">


### PR DESCRIPTION
the status of event in admin page should be changed.
If the event date already passed, the status shows gray circle which means "done".
If the event has reached its maximum number of participants, it will show red circle which means "occupied".
If the event hasn't reached its maximum number of participants and the date hasn't passed, the status will show green circle which means "available".